### PR TITLE
Mutt configuration file setup

### DIFF
--- a/install_required_packages.sh
+++ b/install_required_packages.sh
@@ -49,7 +49,7 @@ touch ~/.mutt/certificates
 
 touch ~/.mutt/muttrc
 
-#Now add the following configuration in the ~/.mutt/muttrc file:
+#Now add the following configuration in the ~/.mutt/muttrc file (removing the # symbols from the beggining of all the lines):
 
 ##set ssl_starttls=yes
 ##set ssl_force_tls=yes


### PR DESCRIPTION
Here I specified that the commentary '#' symbols from the section of the mutt basic file should be removed. In some future I would like to complement it automatically with the script as: ./install_required_packages [gmail account] [gmail password]